### PR TITLE
Fix text contrast in recipe instructions for mobile display

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -689,7 +689,7 @@ export default function RecipeDetailPage() {
               <div className="bg-blue-100 rounded-lg p-6 shadow-sm">
                 <div className="prose max-w-none">
                   {recipe.instructions.split('\n').map((step, index) => (
-                    <p key={index} className="mb-4 leading-relaxed">
+                    <p key={index} className="mb-4 leading-relaxed text-gray-800">
                       {step.trim() && step.trim()}
                     </p>
                   ))}


### PR DESCRIPTION
Added explicit text-gray-800 class to instruction paragraphs to improve readability on mobile devices where the default prose styling was too light against the blue-100 background.

🤖 Generated with [Claude Code](https://claude.ai/code)